### PR TITLE
Sidemenu toggle

### DIFF
--- a/js/bundle.js
+++ b/js/bundle.js
@@ -184,7 +184,7 @@ module.exports = function kreator () {
   sidemenu.addListeners({
     presentationTitle: document.querySelector('.js-handler--presentation-name'),
     themeSelector: document.querySelector('.js-handler--theme-selector'),
-    toggleSidemenu: document.querySelector('.js-handler--hide-sidemenu')
+    hideSidemenu: document.querySelector('.js-handler--hide-sidemenu')
   });
 
   download.addListener(document.querySelector('.js-handler--download'));
@@ -375,7 +375,7 @@ module.exports = {
   addListeners: function(handler) {
     handler.presentationTitle.addEventListener('keyup', setPresentationTitle, false);
     handler.themeSelector.addEventListener('change', changeTheme, false);
-    handler.toggleSidemenu.addEventListener('click', toggleSidemenu, false);
+    handler.hideSidemenu.addEventListener('click', hideSidemenu, false);
     document.querySelector('.sidemenu').addEventListener('mouseover', showSidemenu, false);
   }
 };
@@ -405,7 +405,7 @@ function removeCSS(val) {
   }
 }
 
-function toggleSidemenu() {
+function hideSidemenu() {
   var el = this.parentNode;
   el.style.mozTransform = 'translateX(-90%)';
   el.style.webkitTransform = 'translateX(-90%)';

--- a/js/kreator.js
+++ b/js/kreator.js
@@ -48,7 +48,7 @@ module.exports = function kreator () {
   sidemenu.addListeners({
     presentationTitle: document.querySelector('.js-handler--presentation-name'),
     themeSelector: document.querySelector('.js-handler--theme-selector'),
-    toggleSidemenu: document.querySelector('.js-handler--hide-sidemenu')
+    hideSidemenu: document.querySelector('.js-handler--hide-sidemenu')
   });
 
   download.addListener(document.querySelector('.js-handler--download'));

--- a/js/sidemenu-controller.js
+++ b/js/sidemenu-controller.js
@@ -5,7 +5,7 @@ module.exports = {
   addListeners: function(handler) {
     handler.presentationTitle.addEventListener('keyup', setPresentationTitle, false);
     handler.themeSelector.addEventListener('change', changeTheme, false);
-    handler.toggleSidemenu.addEventListener('click', toggleSidemenu, false);
+    handler.hideSidemenu.addEventListener('click', hideSidemenu, false);
     document.querySelector('.sidemenu').addEventListener('mouseover', showSidemenu, false);
   }
 };
@@ -35,7 +35,7 @@ function removeCSS(val) {
   }
 }
 
-function toggleSidemenu() {
+function hideSidemenu() {
   var el = this.parentNode;
   el.style.mozTransform = 'translateX(-90%)';
   el.style.webkitTransform = 'translateX(-90%)';


### PR DESCRIPTION
Current behavior:
- Press "hide sidemenu"
- move mouse out of there, quickly

You will see that the menu gets back to its initial position since the "show" listener is always on. This addresses that. Also, the function should be called hideSidemenu, not toggle, since it only hides the side menu.
